### PR TITLE
feat: comprehensive debug logging for TUI storage and MCP

### DIFF
--- a/src/bin/totui-mcp.rs
+++ b/src/bin/totui-mcp.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rmcp::{ServiceExt, transport::stdio};
 use std::env;
 use to_tui::mcp::TodoMcpServer;
-use tracing::info;
+use tracing::{debug, error, info};
 use tracing_subscriber::{EnvFilter, fmt};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -15,23 +15,47 @@ async fn main() -> Result<()> {
         println!("totui-mcp {}", VERSION);
         return Ok(());
     }
+
+    // Check for --debug / -v flags to increase verbosity
+    let verbose = args.iter().any(|a| a == "--debug" || a == "-v" || a == "--verbose");
+    let default_filter = if verbose { "debug" } else { "info" };
+    
     fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter)),
         )
         .with_writer(std::io::stderr)
         .with_ansi(true)
         .init();
 
-    info!("Starting todo-mcp server");
+    info!(version = VERSION, "Starting totui-mcp server");
+    debug!("Debug logging enabled");
+    debug!(args = ?args, "Command line arguments");
 
+    debug!("Initializing TodoMcpServer...");
     let server = TodoMcpServer::new();
-    let service = server.serve(stdio()).await?;
+    debug!("TodoMcpServer created successfully");
 
-    info!("Server ready, waiting for requests...");
+    debug!("Setting up stdio transport...");
+    info!("Connecting via stdio transport (stdin/stdout)...");
+    
+    let service = match server.serve(stdio()).await {
+        Ok(s) => {
+            info!("MCP service created successfully");
+            debug!("stdio transport connected");
+            s
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to create MCP service");
+            anyhow::bail!("Failed to create MCP service: {}", e);
+        }
+    };
 
-    service.waiting().await?;
+    info!("Server ready, waiting for requests on stdio...");
+    debug!("Entering main service loop");
 
-    info!("Server shutting down");
+    service.waiting().await.map_err(|e| anyhow::anyhow!("Service error: {}", e))?;
+
+    info!("Server shutting down gracefully");
     Ok(())
 }


### PR DESCRIPTION
## Summary
Adds comprehensive debug/verbose logging throughout the application to help diagnose issues like the undo crash (#5) and MCP connection problems (#1).

Closes #14, relates to #2

## Changes

### Storage/Database Logging (`src/storage/database.rs`)
- `soft_delete_todos_for_project`: Logs IDs being soft-deleted, operation count
- `save_todo_list_for_project`: 
  - Logs all item IDs being saved
  - **Detects soft-deleted items that would conflict** (helpful for undo debugging!)
  - Logs delete counts for both regular and soft-deleted cleanup
  - Traces individual item inserts (at TRACE level)

Example output:
```
DEBUG save_todo_list_for_project: starting save project="default" date="2025-01-29" item_count=3 ids=["abc", "def", "ghi"]
DEBUG Found soft-deleted item with same ID - will be removed to allow insert id="def"
DEBUG Deleted non-soft-deleted items deleted_count=2
DEBUG Removed soft-deleted items that would conflict (undo restoration) soft_deleted_removed=1
```

### Undo Stack Logging (`src/app/state.rs`)
- `save_undo`: Logs stack depth, item count, all IDs
- `undo`: Logs before/after state comparison, shows exactly what's being restored

Example:
```
DEBUG save_undo: pushing state to undo stack stack_depth=2 item_count=3 ids=["a","b","c"]
DEBUG undo: restoring previous state old_item_count=2 new_item_count=3 old_ids=["a","c"] new_ids=["a","b","c"]
```

### MCP Server Logging (`src/bin/totui-mcp.rs`)
- Added `--debug` / `-v` / `--verbose` flags
- Logs initialization steps, transport setup, connection status
- Useful for debugging MCP connection issues (#1)

Example:
```bash
$ totui-mcp --debug 2>&1
INFO Starting totui-mcp server version="0.5.3"
DEBUG Initializing TodoMcpServer...
DEBUG TodoMcpServer created successfully  
DEBUG Setting up stdio transport...
INFO Connecting via stdio transport (stdin/stdout)...
```

## Log Levels
- **INFO**: Major operations (startup, significant actions)
- **DEBUG**: Detailed info (IDs, counts, state changes)
- **TRACE**: Very verbose (individual SQL operations)

## Usage
```bash
# MCP with debug
totui-mcp --debug

# TUI with debug (via env)
RUST_LOG=to_tui=debug totui

# Fine-grained
RUST_LOG=to_tui::storage=debug,to_tui::app=trace totui
```

## Testing
All tests pass. Manually tested MCP startup logging shows connection flow clearly.