### PR TITLE
Release v0.5.14

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "totui-mcp",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "Terminal todo list manager with MCP server integration",
   "owner": {
     "name": "to-tui"
@@ -10,7 +10,7 @@
     {
       "name": "totui-mcp",
       "description": "MCP server for to-tui - terminal todo list manager with daily todos, hierarchical tasks, and rollover support",
-      "version": "0.5.13",
+      "version": "0.5.14",
       "author": {
         "name": "to-tui"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "totui-mcp",
   "description": "MCP server for to-tui - terminal todo list manager with daily todos, hierarchical tasks, and rollover support",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "author": {
     "name": "to-tui"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to to-tui will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.14] - 2026-03-31
 ## [0.5.13] - 2026-03-31
 ## [0.5.12] - 2026-03-31
 ## [0.5.11] - 2026-03-25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,7 +3497,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "to-tui"
-version = "0.5.13"
+version = "0.5.14"
 dependencies = [
  "abi_stable",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "to-tui"
-version = "0.5.13"
+version = "0.5.14"
 edition = "2024"
 
 [lib]

--- a/src/utils/version_check.rs
+++ b/src/utils/version_check.rs
@@ -207,8 +207,11 @@ fn check_latest_app_version() -> Option<AppUpdateInfo> {
 }
 
 /// Compares two semver version strings, returns true if `latest` is newer than `current`
+/// Handles pre-release suffixes like "0.5.11-dev-abc123" by stripping them before comparison.
 fn is_version_newer(latest: &str, current: &str) -> bool {
     let parse_version = |v: &str| -> Option<(u32, u32, u32)> {
+        // Strip pre-release suffix (e.g., "0.5.11-dev-abc" -> "0.5.11")
+        let v = v.split('-').next().unwrap_or(v);
         let parts: Vec<&str> = v.split('.').collect();
         if parts.len() >= 3 {
             Some((
@@ -245,5 +248,11 @@ mod tests {
         assert!(!is_version_newer("0.9.0", "0.9.0"));
         assert!(!is_version_newer("0.8.0", "0.9.0"));
         assert!(!is_version_newer("0.9.0", "1.0.0"));
+
+        // Pre-release suffixes should be stripped
+        assert!(is_version_newer("0.5.13", "0.5.11-dev-abc123"));
+        assert!(is_version_newer("0.5.12", "0.5.11-dev-abc123"));
+        assert!(!is_version_newer("0.5.11", "0.5.11-dev-abc123"));
+        assert!(is_version_newer("0.5.13-rc1", "0.5.11-dev-abc123"));
     }
 }


### PR DESCRIPTION
Release v0.5.14

This PR merges the release commit and updates:
- Cargo.toml version bump
- CHANGELOG.md updates
- Any other version files

The release workflow has already been triggered by the tag push.